### PR TITLE
Migrate Playlist creation to JSON POST request

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Scripts to assist migrating from a Plex Media Server to a Jellyfin Media Server
 3. Create a new local `venv` with `python3 -m venv venv`.
 4. Activate the new `venv` with `source venv/bin/activate`.
 5. Install dependencies with `pip install -r requirements.txt`.
-6. Enter the `scripts` folder.
-7. Copy `creds.py.blank` as `creds.py` and complete the information inside.
+6. Enter the `scripts` folder, `cd scripts`.
+7. Copy `creds.py.blank` as `creds.py`, `cp creds.py.blank creds.py`, and complete the information inside.
    - Getting the Plex token: [https://support.plex.tv/articles/204059436-finding-an-authentication-token-x-plex-token/](https://support.plex.tv/articles/204059436-finding-an-authentication-token-x-plex-token/)
-8. Run a script with `python3 [SCRIPT NAME]`, e.g. `python3 scripts/migrate_playlists.py`.
+8. Run a script with `python3 [SCRIPT NAME]`, e.g. `python3 migrate_playlists.py`.
 
 **Requires Python 3.6+**

--- a/scripts/helpers/jellyfin.py
+++ b/scripts/helpers/jellyfin.py
@@ -124,6 +124,23 @@ class Jellyfin:
             self.authenticate(force_new_auth=True)
         return self._post_request(cmd=cmd, params=params, payload=payload, retried=True)
 
+    def _post_request_json(self, cmd, payload=None, retried=False):
+        try:
+            res = requests.post(
+                f'{self.url}{cmd}?api_key={self.key}',
+                json=payload,
+                headers={'accept': 'application/json', 'Content-Type': 'application/json'}
+            )
+
+            if res:
+                return res
+            return None
+        except:
+            if retried:
+                return None
+            self.authenticate(force_new_auth=True)
+        return self._post_request_json(cmd=cmd, payload=payload, retried=True)
+
     def _post_request_with_token(self, hdr, cmd, data=None, retried=False):
         try:
             hdr = {'accept': 'application/json', 'Content-Type': 'application/json', **hdr}
@@ -231,9 +248,11 @@ class Jellyfin:
         cmd = f'/Playlists'
 
     def makePlaylist(self, name):
-        cmd = f'/Playlists'
-        params = f'{urlencode({"Name": name})}&UserId={self.user_id}'
-        res = self._post_request(cmd=cmd, params=params)
+        res = self._post_request_json(
+            cmd=f'/Playlists',
+            payload={"Name": name, "UserId": self.user_id}
+        )
+
         if res:
             return JellyfinPlaylist(data=res.json())
         return None


### PR DESCRIPTION
Move playlist creation to the updated request schema, as param based requests have been deprecated, see https://api.jellyfin.org/#tag/Playlists/operation/CreatePlaylist

Just whilst I'm here I may as well fix it so it doesn't break when a future release comes out, given 10.9 is meant to be now on our doorstep.

Also a few fixes to the README as I realised the command state didn't align.

<img width="815" alt="Screenshot 2024-03-26 at 09 56 48" src="https://github.com/nwithan8/Plex2Jellyfin/assets/7256684/f54a4305-3c4e-4a35-af9a-4f1046b757e7">