### PR TITLE
Last one; fix gitignore path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 # Secrets
 scripts/creds.py
-.jellyfin_token
+scripts/.jellyfin_token
 
 # Byte-compiled / optimized / DLL files
 __pycache__/


### PR DESCRIPTION
Clean forgot to submit this with the last PR, but just amends the path for the jellyfin token in the gitignore.